### PR TITLE
Bump carbon-dashboards version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@
 
         <carbon.analytics.version>2.1.33</carbon.analytics.version>
         <siddhi.version>4.5.9</siddhi.version>
-        <carbon.dashboards.version>4.0.67</carbon.dashboards.version>
+        <carbon.dashboards.version>4.0.71</carbon.dashboards.version>
 
         <carbon.analytics-common.version>6.1.32</carbon.analytics-common.version>
         <!-- Maven plugins -->


### PR DESCRIPTION
## Purpose
This PR bumps the carbon-dashboards version to 4.0.71.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes